### PR TITLE
Admin dashboard: global exercises CRUD, coach clients & metrics, client detail view

### DIFF
--- a/app/Filament/Resources/Clients/ClientResource.php
+++ b/app/Filament/Resources/Clients/ClientResource.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filament\Resources\Clients;
+
+use App\Filament\Resources\Clients\Pages\ListClients;
+use App\Filament\Resources\Clients\Pages\ViewClient;
+use App\Filament\Resources\Clients\Schemas\ClientInfolist;
+use App\Filament\Resources\Clients\Tables\ClientsTable;
+use App\Models\User;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ClientResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
+
+    protected static ?string $navigationLabel = 'Clients';
+
+    protected static ?string $modelLabel = 'Client';
+
+    protected static ?string $pluralModelLabel = 'Clients';
+
+    protected static ?string $slug = 'clients';
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return ClientInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return ClientsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListClients::route('/'),
+            'view' => ViewClient::route('/{record}'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('role', 'client');
+    }
+}

--- a/app/Filament/Resources/Clients/Pages/ListClients.php
+++ b/app/Filament/Resources/Clients/Pages/ListClients.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Clients\Pages;
+
+use App\Filament\Resources\Clients\ClientResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListClients extends ListRecords
+{
+    protected static string $resource = ClientResource::class;
+}

--- a/app/Filament/Resources/Clients/Pages/ViewClient.php
+++ b/app/Filament/Resources/Clients/Pages/ViewClient.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Clients\Pages;
+
+use App\Filament\Resources\Clients\ClientResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewClient extends ViewRecord
+{
+    protected static string $resource = ClientResource::class;
+}

--- a/app/Filament/Resources/Clients/Schemas/ClientInfolist.php
+++ b/app/Filament/Resources/Clients/Schemas/ClientInfolist.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Clients\Schemas;
 
+use App\Filament\Resources\Users\UserResource;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
@@ -18,7 +19,10 @@ class ClientInfolist
                     ->copyable(),
                 TextEntry::make('coach.name')
                     ->label('Coach')
-                    ->placeholder('No coach assigned'),
+                    ->placeholder('No coach assigned')
+                    ->url(fn ($record): ?string => $record->coach
+                        ? UserResource::getUrl('view', ['record' => $record->coach])
+                        : null),
                 TextEntry::make('created_at')
                     ->dateTime(),
                 TextEntry::make('is_track_only')

--- a/app/Filament/Resources/Clients/Schemas/ClientInfolist.php
+++ b/app/Filament/Resources/Clients/Schemas/ClientInfolist.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Filament\Resources\Clients\Schemas;
+
+use Filament\Infolists\Components\RepeatableEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class ClientInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextEntry::make('name'),
+                TextEntry::make('email')
+                    ->copyable(),
+                TextEntry::make('coach.name')
+                    ->label('Coach')
+                    ->placeholder('No coach assigned'),
+                TextEntry::make('created_at')
+                    ->dateTime(),
+                TextEntry::make('is_track_only')
+                    ->label('Track-only client')
+                    ->badge()
+                    ->state(fn ($record) => $record->is_track_only ? 'Yes' : 'No')
+                    ->color(fn (string $state): string => $state === 'Yes' ? 'warning' : 'success'),
+                Section::make('Tracking Metrics')
+                    ->schema([
+                        RepeatableEntry::make('assignedTrackingMetrics')
+                            ->label('')
+                            ->schema([
+                                TextEntry::make('trackingMetric.name')
+                                    ->label('Metric'),
+                                TextEntry::make('trackingMetric.type')
+                                    ->label('Type')
+                                    ->badge(),
+                                TextEntry::make('trackingMetric.unit')
+                                    ->label('Unit')
+                                    ->placeholder('-'),
+                            ])
+                            ->columns(3),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Clients/Tables/ClientsTable.php
+++ b/app/Filament/Resources/Clients/Tables/ClientsTable.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Resources\Clients\Tables;
 
+use App\Filament\Resources\Users\UserResource;
+use App\Models\User;
 use Filament\Actions\ViewAction;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -21,7 +23,10 @@ class ClientsTable
                 TextColumn::make('coach.name')
                     ->label('Coach')
                     ->sortable()
-                    ->placeholder('—'),
+                    ->placeholder('—')
+                    ->url(fn (User $record): ?string => $record->coach
+                        ? UserResource::getUrl('view', ['record' => $record->coach])
+                        : null),
                 TextColumn::make('assignedTrackingMetrics_count')
                     ->label('Metrics')
                     ->counts('assignedTrackingMetrics')

--- a/app/Filament/Resources/Clients/Tables/ClientsTable.php
+++ b/app/Filament/Resources/Clients/Tables/ClientsTable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Resources\Clients\Tables;
+
+use Filament\Actions\ViewAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ClientsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('email')
+                    ->searchable(),
+                TextColumn::make('coach.name')
+                    ->label('Coach')
+                    ->sortable()
+                    ->placeholder('—'),
+                TextColumn::make('assignedTrackingMetrics_count')
+                    ->label('Metrics')
+                    ->counts('assignedTrackingMetrics')
+                    ->badge(),
+                IconColumn::make('is_track_only')
+                    ->boolean(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([])
+            ->recordActions([
+                ViewAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Exercises/ExerciseResource.php
+++ b/app/Filament/Resources/Exercises/ExerciseResource.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Filament\Resources\Exercises;
+
+use App\Filament\Resources\Exercises\Pages\CreateExercise;
+use App\Filament\Resources\Exercises\Pages\EditExercise;
+use App\Filament\Resources\Exercises\Pages\ListExercises;
+use App\Filament\Resources\Exercises\Schemas\ExerciseForm;
+use App\Filament\Resources\Exercises\Tables\ExercisesTable;
+use App\Models\Exercise;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ExerciseResource extends Resource
+{
+    protected static ?string $model = Exercise::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBolt;
+
+    public static function form(Schema $schema): Schema
+    {
+        return ExerciseForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return ExercisesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListExercises::route('/'),
+            'create' => CreateExercise::route('/create'),
+            'edit' => EditExercise::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->whereNull('coach_id');
+    }
+}

--- a/app/Filament/Resources/Exercises/Pages/CreateExercise.php
+++ b/app/Filament/Resources/Exercises/Pages/CreateExercise.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Filament\Resources\Exercises\Pages;
+
+use App\Filament\Resources\Exercises\ExerciseResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateExercise extends CreateRecord
+{
+    protected static string $resource = ExerciseResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['coach_id'] = null;
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/Exercises/Pages/EditExercise.php
+++ b/app/Filament/Resources/Exercises/Pages/EditExercise.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Exercises\Pages;
+
+use App\Filament\Resources\Exercises\ExerciseResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditExercise extends EditRecord
+{
+    protected static string $resource = ExerciseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Exercises/Pages/ListExercises.php
+++ b/app/Filament/Resources/Exercises/Pages/ListExercises.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Exercises\Pages;
+
+use App\Filament\Resources\Exercises\ExerciseResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListExercises extends ListRecords
+{
+    protected static string $resource = ExerciseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Exercises/Schemas/ExerciseForm.php
+++ b/app/Filament/Resources/Exercises/Schemas/ExerciseForm.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Resources\Exercises\Schemas;
+
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Schema;
+
+class ExerciseForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                Textarea::make('description'),
+                Select::make('muscle_group')
+                    ->required()
+                    ->options([
+                        'chest' => 'Chest',
+                        'back' => 'Back',
+                        'shoulders' => 'Shoulders',
+                        'biceps' => 'Biceps',
+                        'triceps' => 'Triceps',
+                        'forearms' => 'Forearms',
+                        'core' => 'Core',
+                        'quadriceps' => 'Quadriceps',
+                        'hamstrings' => 'Hamstrings',
+                        'glutes' => 'Glutes',
+                        'calves' => 'Calves',
+                        'full_body' => 'Full Body',
+                        'cardio' => 'Cardio',
+                    ]),
+                TextInput::make('video_url')
+                    ->url()
+                    ->maxLength(500),
+                Toggle::make('is_active')
+                    ->default(true),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Exercises/Tables/ExercisesTable.php
+++ b/app/Filament/Resources/Exercises/Tables/ExercisesTable.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Resources\Exercises\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ExercisesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('muscle_group')
+                    ->badge()
+                    ->sortable(),
+                TextColumn::make('description')
+                    ->limit(50)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                IconColumn::make('is_active')
+                    ->boolean(),
+            ])
+            ->filters([])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Users/RelationManagers/ClientsRelationManager.php
+++ b/app/Filament/Resources/Users/RelationManagers/ClientsRelationManager.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Filament\Resources\Users\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ClientsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'clients';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('email')
+                    ->searchable(),
+                TextColumn::make('assignedTrackingMetrics.trackingMetric.name')
+                    ->label('Tracking Metrics')
+                    ->listWithLineBreaks()
+                    ->bulleted()
+                    ->placeholder('None'),
+            ])
+            ->filters([]);
+    }
+}

--- a/app/Filament/Resources/Users/RelationManagers/ClientsRelationManager.php
+++ b/app/Filament/Resources/Users/RelationManagers/ClientsRelationManager.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Resources\Users\RelationManagers;
 
+use App\Filament\Resources\Clients\ClientResource;
+use App\Models\User;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
@@ -22,7 +24,8 @@ class ClientsRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('name')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (User $record): string => ClientResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('email')
                     ->searchable(),
                 TextColumn::make('assignedTrackingMetrics.trackingMetric.name')

--- a/app/Filament/Resources/Users/RelationManagers/ClientsRelationManager.php
+++ b/app/Filament/Resources/Users/RelationManagers/ClientsRelationManager.php
@@ -30,8 +30,7 @@ class ClientsRelationManager extends RelationManager
                     ->searchable(),
                 TextColumn::make('assignedTrackingMetrics.trackingMetric.name')
                     ->label('Tracking Metrics')
-                    ->listWithLineBreaks()
-                    ->bulleted()
+                    ->badge()
                     ->placeholder('None'),
             ])
             ->filters([]);

--- a/app/Filament/Resources/Users/UserResource.php
+++ b/app/Filament/Resources/Users/UserResource.php
@@ -43,7 +43,7 @@ class UserResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            \App\Filament\Resources\Users\RelationManagers\ClientsRelationManager::class,
         ];
     }
 
@@ -59,6 +59,6 @@ class UserResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()->where("role", "coach");
+        return parent::getEloquentQuery()->where('role', 'coach');
     }
 }

--- a/tests/Feature/Admin/ClientResourceTest.php
+++ b/tests/Feature/Admin/ClientResourceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Filament\Resources\Clients\Pages\ListClients;
+use App\Filament\Resources\Clients\Pages\ViewClient;
+use App\Models\TrackingMetric;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create(['role' => 'admin']));
+});
+
+describe('Client Resource', function () {
+    it('lists only clients', function () {
+        $clients = User::factory()->count(3)->create(['role' => 'client']);
+        $coaches = User::factory()->count(2)->create(['role' => 'coach']);
+
+        Livewire::test(ListClients::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords($clients)
+            ->assertCanNotSeeTableRecords($coaches);
+    });
+
+    it('can render the client view page', function () {
+        $client = User::factory()->create(['role' => 'client']);
+
+        Livewire::test(ViewClient::class, ['record' => $client->getRouteKey()])
+            ->assertOk();
+    });
+
+    it('shows coach name on the client view page', function () {
+        $coach = User::factory()->create(['role' => 'coach', 'name' => 'Coach John']);
+        $client = User::factory()->create(['role' => 'client', 'coach_id' => $coach->id]);
+
+        Livewire::test(ViewClient::class, ['record' => $client->getRouteKey()])
+            ->assertSee('Coach John');
+    });
+
+    it('shows assigned tracking metrics on the client view page', function () {
+        $coach = User::factory()->create(['role' => 'coach']);
+        $client = User::factory()->create(['role' => 'client', 'coach_id' => $coach->id]);
+        $metric = TrackingMetric::factory()->create(['coach_id' => $coach->id, 'name' => 'Sleep Quality']);
+
+        $client->assignedTrackingMetrics()->create([
+            'tracking_metric_id' => $metric->id,
+            'order' => 1,
+        ]);
+
+        Livewire::test(ViewClient::class, ['record' => $client->getRouteKey()])
+            ->assertSee('Sleep Quality');
+    });
+});

--- a/tests/Feature/Admin/CoachClientsRelationManagerTest.php
+++ b/tests/Feature/Admin/CoachClientsRelationManagerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Filament\Resources\Users\Pages\ViewUser;
+use App\Filament\Resources\Users\RelationManagers\ClientsRelationManager;
+use App\Models\TrackingMetric;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create(['role' => 'admin']));
+});
+
+describe('Clients Relation Manager', function () {
+    it('can list clients on the coach view page', function () {
+        $coach = User::factory()->create(['role' => 'coach']);
+        $clients = User::factory()->count(3)->create(['role' => 'client', 'coach_id' => $coach->id]);
+        $otherClient = User::factory()->create(['role' => 'client']);
+
+        Livewire::test(ClientsRelationManager::class, [
+            'ownerRecord' => $coach,
+            'pageClass' => ViewUser::class,
+        ])
+            ->assertOk()
+            ->assertCanSeeTableRecords($clients)
+            ->assertCanNotSeeTableRecords([$otherClient]);
+    });
+
+    it('shows tracking metrics for each client', function () {
+        $coach = User::factory()->create(['role' => 'coach']);
+        $client = User::factory()->create(['role' => 'client', 'coach_id' => $coach->id]);
+        $metric = TrackingMetric::factory()->create(['coach_id' => $coach->id, 'name' => 'Body Weight']);
+
+        $client->assignedTrackingMetrics()->create([
+            'tracking_metric_id' => $metric->id,
+            'order' => 1,
+        ]);
+
+        Livewire::test(ClientsRelationManager::class, [
+            'ownerRecord' => $coach,
+            'pageClass' => ViewUser::class,
+        ])
+            ->assertOk()
+            ->assertSee('Body Weight');
+    });
+});

--- a/tests/Feature/Admin/ExerciseResourceTest.php
+++ b/tests/Feature/Admin/ExerciseResourceTest.php
@@ -56,12 +56,12 @@ describe('Exercise Resource', function () {
     });
 
     it('can edit a global exercise', function () {
-        $exercise = Exercise::factory()->create(['coach_id' => null]);
+        $exercise = Exercise::factory()->create(['coach_id' => null, 'muscle_group' => 'chest']);
 
         Livewire::test(EditExercise::class, ['record' => $exercise->getRouteKey()])
-            ->fillForm(['name' => 'Updated Name'])
+            ->fillForm(['name' => 'Updated Name', 'muscle_group' => 'chest'])
             ->call('save')
-            ->assertNotified();
+            ->assertHasNoFormErrors();
 
         expect($exercise->fresh()->name)->toBe('Updated Name');
     });

--- a/tests/Feature/Admin/ExerciseResourceTest.php
+++ b/tests/Feature/Admin/ExerciseResourceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Filament\Resources\Exercises\Pages\CreateExercise;
+use App\Filament\Resources\Exercises\Pages\EditExercise;
+use App\Filament\Resources\Exercises\Pages\ListExercises;
+use App\Models\Exercise;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create(['role' => 'admin']));
+});
+
+describe('Exercise Resource', function () {
+    it('can render the list page with global exercises only', function () {
+        $globalExercises = Exercise::factory()->count(3)->create(['coach_id' => null]);
+        $coachExercises = Exercise::factory()->count(2)->create([
+            'coach_id' => User::factory()->create(['role' => 'coach'])->id,
+        ]);
+
+        Livewire::test(ListExercises::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords($globalExercises)
+            ->assertCanNotSeeTableRecords($coachExercises);
+    });
+
+    it('can render the create page', function () {
+        Livewire::test(CreateExercise::class)
+            ->assertOk();
+    });
+
+    it('can create a global exercise', function () {
+        $data = Exercise::factory()->make(['coach_id' => null]);
+
+        Livewire::test(CreateExercise::class)
+            ->fillForm([
+                'name' => $data->name,
+                'description' => $data->description,
+                'muscle_group' => $data->muscle_group,
+                'is_active' => true,
+            ])
+            ->call('create')
+            ->assertNotified();
+
+        $this->assertDatabaseHas(Exercise::class, [
+            'name' => $data->name,
+            'coach_id' => null,
+        ]);
+    });
+
+    it('can render the edit page', function () {
+        $exercise = Exercise::factory()->create(['coach_id' => null]);
+
+        Livewire::test(EditExercise::class, ['record' => $exercise->getRouteKey()])
+            ->assertOk();
+    });
+
+    it('can edit a global exercise', function () {
+        $exercise = Exercise::factory()->create(['coach_id' => null]);
+
+        Livewire::test(EditExercise::class, ['record' => $exercise->getRouteKey()])
+            ->fillForm(['name' => 'Updated Name'])
+            ->call('save')
+            ->assertNotified();
+
+        expect($exercise->fresh()->name)->toBe('Updated Name');
+    });
+});


### PR DESCRIPTION
## Summary

- **Global exercises CRUD** — new `ExerciseResource` in the Filament admin panel for managing exercises available to all coaches (`coach_id = null`); full create/edit/delete with muscle group, description, video URL, and active toggle
- **Coach clients & metrics** — `ClientsRelationManager` added to the coach view page, listing each coach's clients with their assigned tracking metrics displayed as inline pills
- **Client detail view** — new `ClientResource` (admin read-only) with a list page and detail infolist showing client profile, their coach (linked), and all assigned tracking metrics (name, type, unit)
- **Cross-linked navigation** — client names in the coach view link to the client detail page; coach name on the client detail page links back to the coach view

## Test plan

- [x] `php artisan test --compact tests/Feature/Admin/` — all 11 tests pass
- [ ] Admin panel: navigate to Exercises, create a global exercise, verify it appears and coach-specific exercises are not shown
- [ ] Admin panel: open a coach's view page, verify the Clients tab lists their clients with metric pills
- [ ] Admin panel: click a client name in the relation manager, verify it navigates to the client detail page
- [ ] Admin panel: on the client detail page, verify coach name is a clickable link back to the coach view
- [ ] Admin panel: navigate to Clients list, verify only clients are shown (no coaches/admins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)