### PR TITLE
feat: add metrics onboarding popup for coaches on first sign-in

### DIFF
--- a/app/Http/Controllers/Coach/MetricsSetupController.php
+++ b/app/Http/Controllers/Coach/MetricsSetupController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Coach;
+
+use App\Http\Controllers\Controller;
+use App\Models\TrackingMetric;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class MetricsSetupController extends Controller
+{
+    public function __invoke(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'setup' => ['required', 'boolean'],
+        ]);
+
+        $coach = auth()->user();
+        $coach->update(['metrics_onboarded_at' => now()]);
+
+        if ($validated['setup']) {
+            TrackingMetric::seedDefaults($coach->id, $coach->locale ?? 'en');
+
+            return redirect()->route('coach.dashboard')->with(
+                'metrics_setup',
+                __('coach.metrics_setup.seeded', ['url' => route('coach.tracking-metrics.index')])
+            );
+        }
+
+        return redirect()->route('coach.dashboard')->with(
+            'metrics_setup',
+            __('coach.metrics_setup.skipped', ['url' => route('coach.tracking-metrics.index')])
+        );
+    }
+}

--- a/app/Models/TrackingMetric.php
+++ b/app/Models/TrackingMetric.php
@@ -50,20 +50,45 @@ class TrackingMetric extends Model
     }
 
     /**
-     * Preseed default metrics for a coach.
+     * Seed default metrics for a coach, using their locale for names.
      *
      * @return array<int, self>
      */
-    public static function seedDefaults(int $coachId): array
+    public static function seedDefaults(int $coachId, string $locale = 'en'): array
     {
         $defaults = [
-            ['name' => 'Body Weight', 'type' => 'number', 'unit' => 'kg', 'order' => 1],
-            ['name' => 'Steps', 'type' => 'number', 'unit' => 'steps', 'order' => 2],
-            ['name' => 'Sleep Quality', 'type' => 'scale', 'order' => 3],
-            ['name' => 'Energy Level', 'type' => 'scale', 'order' => 4],
-            ['name' => 'Mood', 'type' => 'scale', 'order' => 5],
-            ['name' => 'Took Supplements', 'type' => 'boolean', 'order' => 6],
-            ['name' => 'Daily Notes', 'type' => 'text', 'order' => 7],
+            [
+                'name' => __('coach.default_metrics.weight', locale: $locale),
+                'type' => 'number',
+                'unit' => 'kg',
+                'order' => 1,
+            ],
+            [
+                'name' => __('coach.default_metrics.steps', locale: $locale),
+                'type' => 'number',
+                'unit' => 'steps',
+                'order' => 2,
+            ],
+            [
+                'name' => __('coach.default_metrics.progress_image', locale: $locale),
+                'type' => 'image',
+                'order' => 3,
+            ],
+            [
+                'name' => __('coach.default_metrics.mood', locale: $locale),
+                'type' => 'scale',
+                'order' => 4,
+            ],
+            [
+                'name' => __('coach.default_metrics.energy', locale: $locale),
+                'type' => 'scale',
+                'order' => 5,
+            ],
+            [
+                'name' => __('coach.default_metrics.sleep', locale: $locale),
+                'type' => 'scale',
+                'order' => 6,
+            ],
         ];
 
         $metrics = [];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,6 +44,7 @@ class User extends Authenticatable implements FilamentUser
         'dark_mode',
         'locale',
         'is_track_only',
+        'metrics_onboarded_at',
     ];
 
     /**
@@ -68,6 +69,7 @@ class User extends Authenticatable implements FilamentUser
             'password' => 'hashed',
             'dark_mode' => 'boolean',
             'is_track_only' => 'boolean',
+            'metrics_onboarded_at' => 'datetime',
         ];
     }
 

--- a/database/migrations/2026_03_26_210927_add_metrics_onboarded_at_to_users_table.php
+++ b/database/migrations/2026_03_26_210927_add_metrics_onboarded_at_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->timestamp('metrics_onboarded_at')->nullable()->after('locale');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('metrics_onboarded_at');
+        });
+    }
+};

--- a/lang/en/coach.php
+++ b/lang/en/coach.php
@@ -790,4 +790,22 @@ return [
         'no_redemptions' => 'No redemptions yet',
         'no_redemptions_description' => 'Redemption requests from your clients will appear here.',
     ],
+
+    'default_metrics' => [
+        'weight' => 'Body Weight',
+        'steps' => 'Steps',
+        'progress_image' => 'Progress Image',
+        'mood' => 'Mood',
+        'energy' => 'Energy Level',
+        'sleep' => 'Sleep Quality',
+    ],
+
+    'metrics_setup' => [
+        'title' => 'Set Up Your Tracking Metrics',
+        'description' => 'Would you like us to add some default tracking metrics to your account? We\'ll add: Body Weight, Steps, Progress Image, Mood, Energy Level, and Sleep Quality.',
+        'yes' => 'Yes, add them',
+        'skip' => 'Skip for now',
+        'seeded' => 'Default metrics added. You can manage them in the <a href=":url" class="font-semibold underline">Tracking</a> section.',
+        'skipped' => 'No problem. You can create metrics anytime in the <a href=":url" class="font-semibold underline">Tracking</a> section.',
+    ],
 ];

--- a/lang/hr/coach.php
+++ b/lang/hr/coach.php
@@ -787,4 +787,22 @@ return [
         'no_redemptions' => 'Još nema iskorištavanja',
         'no_redemptions_description' => 'Zahtjevi za iskorištavanje vaših klijenata pojavit će se ovdje.',
     ],
+
+    'default_metrics' => [
+        'weight' => 'Tjelesna težina',
+        'steps' => 'Koraci',
+        'progress_image' => 'Slika napretka',
+        'mood' => 'Raspoloženje',
+        'energy' => 'Razina energije',
+        'sleep' => 'Kvaliteta sna',
+    ],
+
+    'metrics_setup' => [
+        'title' => 'Postavi metrike praćenja',
+        'description' => 'Želite li da dodamo neke zadane metrike praćenja na vaš račun? Dodat ćemo: tjelesnu težinu, korake, sliku napretka, raspoloženje, razinu energije i kvalitetu sna.',
+        'yes' => 'Da, dodaj ih',
+        'skip' => 'Preskoči za sada',
+        'seeded' => 'Zadane metrike su dodane. Možete ih upravljati u odjeljku <a href=":url" class="font-semibold underline">Praćenje</a>.',
+        'skipped' => 'Nema problema. Metrike možete kreirati u bilo koje vrijeme u odjeljku <a href=":url" class="font-semibold underline">Praćenje</a>.',
+    ],
 ];

--- a/lang/sl/coach.php
+++ b/lang/sl/coach.php
@@ -787,4 +787,22 @@ return [
         'no_redemptions' => 'Še ni unovčitev',
         'no_redemptions_description' => 'Zahteve za unovčitev vaših strank bodo prikazane tukaj.',
     ],
+
+    'default_metrics' => [
+        'weight' => 'Telesna teža',
+        'steps' => 'Koraki',
+        'progress_image' => 'Slika napredka',
+        'mood' => 'Razpoloženje',
+        'energy' => 'Raven energije',
+        'sleep' => 'Kakovost spanja',
+    ],
+
+    'metrics_setup' => [
+        'title' => 'Nastavi metrike sledenja',
+        'description' => 'Ali želite, da dodamo nekaj privzetih metrik sledenja na vaš račun? Dodali bomo: telesno težo, korake, sliko napredka, razpoloženje, raven energije in kakovost spanja.',
+        'yes' => 'Da, dodaj jih',
+        'skip' => 'Preskoči za zdaj',
+        'seeded' => 'Privzete metrike so dodane. Upravljate jih lahko v razdelku <a href=":url" class="font-semibold underline">Sledenje</a>.',
+        'skipped' => 'Ni problema. Metrike lahko ustvarite kadarkoli v razdelku <a href=":url" class="font-semibold underline">Sledenje</a>.',
+    ],
 ];

--- a/resources/views/coach/dashboard.blade.php
+++ b/resources/views/coach/dashboard.blade.php
@@ -2,6 +2,69 @@
     <x-slot:title>{{ __('coach.dashboard.heading') }}</x-slot:title>
 
     <div class="space-y-6">
+        {{-- Metrics setup flash banner --}}
+        @if(session('metrics_setup'))
+            <div class="rounded-md bg-green-50 dark:bg-green-900/20 p-4">
+                <div class="flex">
+                    <div class="flex-shrink-0">
+                        <svg class="h-5 w-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                        </svg>
+                    </div>
+                    <div class="ml-3">
+                        <p class="text-sm font-medium text-green-800 dark:text-green-200">{!! session('metrics_setup') !!}</p>
+                    </div>
+                </div>
+            </div>
+        @endif
+
+        {{-- First-time metrics setup popup --}}
+        @if(auth()->user()->metrics_onboarded_at === null)
+            <div x-data="{ open: true }" x-show="open" class="fixed inset-0 z-50 overflow-y-auto" aria-labelledby="metrics-setup-title" role="dialog" aria-modal="true">
+                <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:p-0">
+                    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+
+                    <div class="inline-block align-bottom bg-white dark:bg-gray-900 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+                        <div>
+                            <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 dark:bg-blue-900">
+                                <svg class="h-6 w-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+                                </svg>
+                            </div>
+                            <div class="mt-3 text-center sm:mt-5">
+                                <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100" id="metrics-setup-title">
+                                    {{ __('coach.metrics_setup.title') }}
+                                </h3>
+                                <div class="mt-2">
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                                        {{ __('coach.metrics_setup.description') }}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="mt-5 sm:mt-6 flex flex-col sm:flex-row gap-3">
+                            <form method="POST" action="{{ route('coach.metrics-setup') }}" class="flex-1">
+                                @csrf
+                                <input type="hidden" name="setup" value="1">
+                                <button type="submit" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-blue-600 text-base font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:text-sm">
+                                    {{ __('coach.metrics_setup.yes') }}
+                                </button>
+                            </form>
+
+                            <form method="POST" action="{{ route('coach.metrics-setup') }}" class="flex-1">
+                                @csrf
+                                <input type="hidden" name="setup" value="0">
+                                <button type="submit" class="w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-700 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:text-sm">
+                                    {{ __('coach.metrics_setup.skip') }}
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endif
+
         <!-- Welcome Message -->
         <div>
             <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ __('coach.dashboard.welcome', ['name' => auth()->user()->name]) }}</h1>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,6 +92,7 @@ Route::middleware(['auth', 'verified', 'role:coach'])
         Route::post('tracking-metrics/{trackingMetric}/restore', [Coach\TrackingMetricController::class, 'restore'])->name('tracking-metrics.restore');
         Route::post('tracking-metrics/{trackingMetric}/move-up', [Coach\TrackingMetricController::class, 'moveUp'])->name('tracking-metrics.move-up');
         Route::post('tracking-metrics/{trackingMetric}/move-down', [Coach\TrackingMetricController::class, 'moveDown'])->name('tracking-metrics.move-down');
+        Route::post('metrics-setup', Coach\MetricsSetupController::class)->name('metrics-setup');
         Route::get('messages', [Coach\MessageController::class, 'index'])->name('messages.index');
         Route::get('messages/{user}', [Coach\MessageController::class, 'show'])->name('messages.show');
         Route::post('messages/{user}', [Coach\MessageController::class, 'store'])->name('messages.store');

--- a/tests/Feature/Coach/MetricsSetupTest.php
+++ b/tests/Feature/Coach/MetricsSetupTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\TrackingMetric;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->coach = User::factory()->coach()->create(['metrics_onboarded_at' => null]);
+});
+
+test('dashboard shows metrics setup popup when metrics_onboarded_at is null', function () {
+    $this->actingAs($this->coach)
+        ->get(route('coach.dashboard'))
+        ->assertOk()
+        ->assertSee(__('coach.metrics_setup.title'));
+});
+
+test('dashboard does not show popup when metrics_onboarded_at is set', function () {
+    $this->coach->update(['metrics_onboarded_at' => now()]);
+
+    $this->actingAs($this->coach)
+        ->get(route('coach.dashboard'))
+        ->assertOk()
+        ->assertDontSee(__('coach.metrics_setup.title'));
+});
+
+test('choosing yes seeds 6 default metrics and sets metrics_onboarded_at', function () {
+    $this->actingAs($this->coach)
+        ->post(route('coach.metrics-setup'), ['setup' => '1'])
+        ->assertRedirect(route('coach.dashboard'));
+
+    $this->coach->refresh();
+
+    expect($this->coach->metrics_onboarded_at)->not->toBeNull();
+    expect(TrackingMetric::where('coach_id', $this->coach->id)->count())->toBe(6);
+});
+
+test('choosing skip sets metrics_onboarded_at without creating metrics', function () {
+    $this->actingAs($this->coach)
+        ->post(route('coach.metrics-setup'), ['setup' => '0'])
+        ->assertRedirect(route('coach.dashboard'));
+
+    $this->coach->refresh();
+
+    expect($this->coach->metrics_onboarded_at)->not->toBeNull();
+    expect(TrackingMetric::where('coach_id', $this->coach->id)->count())->toBe(0);
+});
+
+test('yes path seeds metrics with localized names for hr locale', function () {
+    $this->coach->update(['locale' => 'hr']);
+
+    $this->actingAs($this->coach)
+        ->post(route('coach.metrics-setup'), ['setup' => '1'])
+        ->assertRedirect(route('coach.dashboard'));
+
+    expect(TrackingMetric::where('coach_id', $this->coach->id)
+        ->where('name', __('coach.default_metrics.weight', locale: 'hr'))
+        ->exists()
+    )->toBeTrue();
+});
+
+test('yes path seeds metrics with localized names for sl locale', function () {
+    $this->coach->update(['locale' => 'sl']);
+
+    $this->actingAs($this->coach)
+        ->post(route('coach.metrics-setup'), ['setup' => '1'])
+        ->assertRedirect(route('coach.dashboard'));
+
+    expect(TrackingMetric::where('coach_id', $this->coach->id)
+        ->where('name', __('coach.default_metrics.weight', locale: 'sl'))
+        ->exists()
+    )->toBeTrue();
+});
+
+test('setup route requires authentication', function () {
+    $this->post(route('coach.metrics-setup'), ['setup' => '1'])
+        ->assertRedirect(route('login'));
+});
+
+test('client cannot access coach metrics setup route', function () {
+    $client = User::factory()->client()->create(['coach_id' => $this->coach->id]);
+
+    $this->actingAs($client)
+        ->post(route('coach.metrics-setup'), ['setup' => '1'])
+        ->assertRedirect(route('client.dashboard'));
+});


### PR DESCRIPTION
## Summary

- Adds a one-time modal popup on the coach dashboard that appears on first sign-in (gated by new `metrics_onboarded_at` nullable timestamp on `users`)
- **Yes** — seeds 6 default tracking metrics localized to the coach's locale (weight, steps, progress image, mood, energy, sleep), then shows a flash with a link to the Tracking section
- **No / Skip** — sets the timestamp and shows a flash informing the coach where to create metrics later
- Metric names are fully localized in English, Croatian, and Slovenian

## Test plan

- [ ] 8 feature tests pass (`php artisan test --compact --filter=MetricsSetupTest`)
- [ ] Dashboard shows popup for a coach with `metrics_onboarded_at = null`
- [ ] Dashboard does not show popup after either choice is made
- [ ] Choosing "Yes" creates exactly 6 metrics with locale-appropriate names
- [ ] Choosing "Skip" creates no metrics but sets the timestamp
- [ ] Flash banner with Tracking section link appears after either choice
- [ ] Unauthenticated users are redirected to login
- [ ] Clients cannot access the metrics-setup route

🤖 Generated with [Claude Code](https://claude.com/claude-code)